### PR TITLE
Rewrite integer and float range functions using generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ranger 🧝‍♂️
 =========
 
-The missing range functions for Go. Generating a range of numbers or characters ([intervals](https://en.wikipedia.org/wiki/Interval_(mathematics))) is an inane but useful task – perfect for a computer. 
+The missing range functions for Go. Generating a range of numbers or characters ([intervals](https://en.wikipedia.org/wiki/Interval_(mathematics))) is an inane but useful task – perfect for a computer.
 
 I missed the [range](https://ruby-doc.org/core-2.5.1/Range.html) type in Ruby so I wrote this.
 
@@ -19,21 +19,21 @@ Examples
 ```go
 // Integer intervals
 // ----------------
-numbers := ranger.Int(1, 10)
+numbers := ranger.Range[int](1, 10)
 fmt.Printf("%v", numbers) // [1 2 3 4 5 6 7 8 9 10]
 
-odds := ranger.Int(1, 10, ranger.Step(2))
+odds := ranger.Range[int](1, 10, ranger.Step(2))
 fmt.Printf("%v", odds) // [1 3 5 7 9]
 
-littleNumbers := ranger.Int8(1, 127)
+littleNumbers := ranger.Range[int8](1, 127)
 fmt.Printf("%v", littleNumbers) // [1 2 3 4...for a little while]
 
-bigNumbers := ranger.Int64(1, 1000000)
+bigNumbers := ranger.Range[int64](1, 1000000)
 fmt.Printf("%v", bigNumbers) // [1 2 3 4...for a long while]
 
 // Float intervals
 // ---------------
-floats := ranger.Float32(1, 2.5, ranger.FloatStep(0.5))
+floats := ranger.Range[float32](1, 2.5, ranger.Step(0.5))
 fmt.Printf("%v", floats) // [1.0 1.5 2.0 2.5]
 
 // Character intervals
@@ -51,3 +51,17 @@ for _, letter := range alphabet {
 fmt.Println("Now I know my ABCs!")
 ```
 
+Development
+-----------
+
+To run all tests:
+
+```
+go test ./...
+```
+
+To run benchmarks:
+
+```
+go test -bench ./...
+```

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,14 @@
 module github.com/qsymmachus/ranger
 
-go 1.15
+go 1.18
 
-require github.com/stretchr/testify v1.6.1
+require (
+	github.com/stretchr/testify v1.6.1
+	golang.org/x/exp v0.0.0-20220325121720-054d8573a5d8
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/exp v0.0.0-20220325121720-054d8573a5d8 h1:Xt4/LzbTwfocTk9ZLEu4onjeFucl88iW+v4j4PWbQuE=
+golang.org/x/exp v0.0.0-20220325121720-054d8573a5d8/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=

--- a/ranger.go
+++ b/ranger.go
@@ -1,261 +1,59 @@
 // Range functions for Go. Easily generate intervals of integers, floats, runes, and strings.
 package ranger
 
-import "fmt"
+import (
+	"fmt"
+
+	"golang.org/x/exp/constraints"
+)
+
+type Number interface {
+	constraints.Integer | constraints.Float
+}
 
 // Options applied to all range functions in this package.
-type options struct {
-	step      int
-	floatStep float32
+type options[N Number] struct {
+	step N
 }
 
 // An Option is just a function that changes the provided options struct.
 // All range functions in this package accept Options as variadic arguments,
 // so you can pass (optional!) options like step size.
-type Option func(*options)
+type Option[N Number] func(*options[N])
 
 // The Step option changes the increment ("step") between values in generated
 // intervals. If this option is omitted, the step defaults to 1.
-func Step(size int) func(*options) {
-	return func(opts *options) {
+func Step[N Number](size N) func(*options[N]) {
+	return func(opts *options[N]) {
 		opts.step = size
 	}
 }
 
-// FloatStep changes the increment ("step") between values in a generated
-// interval of floats. If this option is omitted, the step defaults to 1.
-// If both FloatStep and Step are provided as options, FloatStep takes
-// precedence.
-func FloatStep(size float32) func(*options) {
-	return func(opts *options) {
-		opts.floatStep = size
-	}
-}
-
 // Applies a list of option functions to the underlying options struct.
-func (o *options) mergeOptions(opts ...Option) {
+func (o *options[N]) mergeOptions(opts ...Option[N]) {
 	// Initialize defaults
 	o.step = 1
-	o.floatStep = 1.0
 
 	for _, opt := range opts {
 		opt(o)
 	}
 }
 
-// Returns an interval slice of ints, with the specified start and end value.
+// Returns an interval slice of numbers, with the specified start and end value.
 // Values between the start and end are incremented ("stepped") by 1, unless a
 // different step option is provided. If the end value is smaller than the
 // start value, returns an empty slice.
-func Int(start, end int, opts ...Option) []int {
+func Range[N Number](start, end N, opts ...Option[N]) []N {
 	if start > end {
-		return []int{}
+		return []N{}
 	}
 
-	options := options{}
+	options := options[N]{}
 	options.mergeOptions(opts...)
-	vals := make([]int, ((end-start)/options.step)+1)
+	vals := make([]N, int(((end-start)/options.step)+1))
 	for i := range vals {
 		vals[i] = start
 		start += options.step
-	}
-
-	return vals
-}
-
-// Returns an interval slice of int8s, with the specified start and end value.
-// Values between the start and end are incremented ("stepped") by 1, unless a
-// different step option is provided. If the end value is smaller than the
-// start value, returns an empty slice.
-func Int8(start, end int8, opts ...Option) []int8 {
-	if start > end {
-		return []int8{}
-	}
-
-	options := options{}
-	options.mergeOptions(opts...)
-	vals := make([]int8, ((end-start)/int8(options.step))+1)
-	for i := range vals {
-		vals[i] = start
-		start += int8(options.step)
-	}
-
-	return vals
-}
-
-// Returns an interval slice of int16s, with the specified start and end value.
-// Values between the start and end are incremented ("stepped") by 1, unless a
-// different step option is provided. If the end value is smaller than the
-// start value, returns an empty slice.
-func Int16(start, end int16, opts ...Option) []int16 {
-	if start > end {
-		return []int16{}
-	}
-
-	options := options{}
-	options.mergeOptions(opts...)
-	vals := make([]int16, ((end-start)/int16(options.step))+1)
-	for i := range vals {
-		vals[i] = start
-		start += int16(options.step)
-	}
-
-	return vals
-}
-
-// Returns an interval slice of int64s, with the specified start and end value.
-// Values between the start and end are incremented ("stepped") by 1, unless a
-// different step option is provided. If the end value is smaller than the
-// start value, returns an empty slice.
-func Int64(start, end int64, opts ...Option) []int64 {
-	if start > end {
-		return []int64{}
-	}
-
-	options := options{}
-	options.mergeOptions(opts...)
-	vals := make([]int64, ((end-start)/int64(options.step))+1)
-	for i := range vals {
-		vals[i] = start
-		start += int64(options.step)
-	}
-
-	return vals
-}
-
-// Returns an interval slice of uints, with the specified start and end value.
-// Values between the start and end are incremented ("stepped") by 1, unless a
-// different step option is provided. If the end value is smaller than the
-// start value, returns an empty slice.
-func Uint(start, end uint, opts ...Option) []uint {
-	if start > end {
-		return []uint{}
-	}
-
-	options := options{}
-	options.mergeOptions(opts...)
-	vals := make([]uint, ((end-start)/uint(options.step))+1)
-	for i := range vals {
-		vals[i] = start
-		start += uint(options.step)
-	}
-
-	return vals
-}
-
-// Returns an interval slice of uint8s, with the specified start and end value.
-// Values between the start and end are incremented ("stepped") by 1, unless a
-// different step option is provided. If the end value is smaller than the
-// start value, returns an empty slice.
-func Uint8(start, end uint8, opts ...Option) []uint8 {
-	if start > end {
-		return []uint8{}
-	}
-
-	options := options{}
-	options.mergeOptions(opts...)
-	vals := make([]uint8, ((end-start)/uint8(options.step))+1)
-	for i := range vals {
-		vals[i] = start
-		start += uint8(options.step)
-	}
-
-	return vals
-}
-
-// Returns an interval slice of uint16s, with the specified start and end value.
-// Values between the start and end are incremented ("stepped") by 1, unless a
-// different step option is provided. If the end value is smaller than the
-// start value, returns an empty slice.
-func Uint16(start, end uint16, opts ...Option) []uint16 {
-	if start > end {
-		return []uint16{}
-	}
-
-	options := options{}
-	options.mergeOptions(opts...)
-	vals := make([]uint16, ((end-start)/uint16(options.step))+1)
-	for i := range vals {
-		vals[i] = start
-		start += uint16(options.step)
-	}
-
-	return vals
-}
-
-// Returns an interval slice of uint64s, with the specified start and end value.
-// Values between the start and end are incremented ("stepped") by 1, unless a
-// different step option is provided. If the end value is smaller than the
-// start value, returns an empty slice.
-func Uint64(start, end uint64, opts ...Option) []uint64 {
-	if start > end {
-		return []uint64{}
-	}
-
-	options := options{}
-	options.mergeOptions(opts...)
-	vals := make([]uint64, ((end-start)/uint64(options.step))+1)
-	for i := range vals {
-		vals[i] = start
-		start += uint64(options.step)
-	}
-
-	return vals
-}
-
-// Returns an interval slice of float32s, with the specified start and end value.
-// Values between the start and end are incremented ("stepped") by 1, unless a
-// different step option is provided. A FloatStep option takes precedence over a
-// Step option. If the end value is smaller than the start value, returns an
-// empty slice.
-func Float32(start, end float32, opts ...Option) []float32 {
-	if start > end {
-		return []float32{}
-	}
-
-	options := options{}
-	options.mergeOptions(opts...)
-
-	var step float32
-	if options.floatStep != 1.0 {
-		step = options.floatStep
-	} else {
-		step = float32(options.step)
-	}
-
-	vals := make([]float32, int(((end-start)/step)+1))
-	for i := range vals {
-		vals[i] = start
-		start += step
-	}
-
-	return vals
-}
-
-// Returns an interval slice of float64s, with the specified start and end value.
-// Values between the start and end are incremented ("stepped") by 1, unless a
-// different step option is provided. A FloatStep option takes precedence over a
-// Step option. If the end value is smaller than the start value, returns an
-// empty slice.
-func Float64(start, end float64, opts ...Option) []float64 {
-	if start > end {
-		return []float64{}
-	}
-
-	options := options{}
-	options.mergeOptions(opts...)
-
-	var step float64
-	if options.floatStep != 1.0 {
-		step = float64(options.floatStep)
-	} else {
-		step = float64(options.step)
-	}
-
-	vals := make([]float64, int(((end-start)/step)+1))
-	for i := range vals {
-		vals[i] = start
-		start += step
 	}
 
 	return vals
@@ -266,12 +64,12 @@ func Float64(start, end float64, opts ...Option) []float64 {
 // value, and casting that value back into a rune. The step value is 1, unless
 // a different step option is provided. If the end value is smaller than the
 // start value, returns an empty slice.
-func Rune(start, end rune, opts ...Option) []rune {
+func Rune(start, end rune, opts ...Option[int]) []rune {
 	if start > end {
 		return []rune{}
 	}
 
-	options := options{}
+	options := options[int]{}
 	options.mergeOptions(opts...)
 	vals := make([]rune, ((int(end)-int(start))/options.step)+1)
 	for i := range vals {
@@ -288,7 +86,7 @@ func Rune(start, end rune, opts ...Option) []rune {
 // or an error is returned. The step value is 1, unless a different step
 // option is provided. If the end value is smaller than the start value,
 // returns an empty slice.
-func String(start, end string, opts ...Option) ([]string, error) {
+func String(start, end string, opts ...Option[int]) ([]string, error) {
 	startRunes := []rune(start)
 	if len(startRunes) > 1 {
 		return []string{}, fmt.Errorf("Start string '%s' contains more than one character", start)

--- a/ranger_test.go
+++ b/ranger_test.go
@@ -6,16 +6,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestInt(t *testing.T) {
-	type testVals struct {
-		start    int
-		end      int
-		step     int
-		expected []int
-	}
+type testVals[N Number] struct {
+	start    N
+	end      N
+	step     N
+	expected []N
+}
 
+func TestInt(t *testing.T) {
 	t.Run("It should generate intervals with a default step of 1", func(t *testing.T) {
-		tests := []testVals{
+		tests := []testVals[int]{
 			{1, 10, 1, []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
 			{-5, 5, 1, []int{-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5}},
 			{7, 7, 1, []int{7}},
@@ -23,39 +23,33 @@ func TestInt(t *testing.T) {
 		}
 
 		for _, test := range tests {
-			assert.Equal(t, test.expected, Int(test.start, test.end))
+			assert.Equal(t, test.expected, Range[int](test.start, test.end))
 		}
 	})
 
 	t.Run("It should generate intervals using the provided 'Step' option", func(t *testing.T) {
-		tests := []testVals{
+		tests := []testVals[int]{
 			{1, 10, 3, []int{1, 4, 7, 10}},
 			{1, 9, 3, []int{1, 4, 7}},
 			{-6, 6, 2, []int{-6, -4, -2, 0, 2, 4, 6}},
 		}
 
 		for _, test := range tests {
-			assert.Equal(t, test.expected, Int(test.start, test.end, Step(test.step)))
+			assert.Equal(t, test.expected, Range[int](test.start, test.end, Step(test.step)))
 		}
 	})
 }
 
 func BenchmarkInt(b *testing.B) {
 	for i := 1; i < b.N; i++ {
-		Int(1, 1000000)
+		Range[int](1, 1000000)
 	}
 }
 
 func TestInt8(t *testing.T) {
-	type testVals struct {
-		start    int8
-		end      int8
-		step     int
-		expected []int8
-	}
 
 	t.Run("It should generate intervals with a default step of 1", func(t *testing.T) {
-		tests := []testVals{
+		tests := []testVals[int8]{
 			{1, 10, 1, []int8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
 			{-5, 5, 1, []int8{-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5}},
 			{7, 7, 1, []int8{7}},
@@ -63,39 +57,32 @@ func TestInt8(t *testing.T) {
 		}
 
 		for _, test := range tests {
-			assert.Equal(t, test.expected, Int8(test.start, test.end))
+			assert.Equal(t, test.expected, Range[int8](test.start, test.end))
 		}
 	})
 
 	t.Run("It should generate intervals using the provided 'Step' option", func(t *testing.T) {
-		tests := []testVals{
+		tests := []testVals[int8]{
 			{1, 10, 3, []int8{1, 4, 7, 10}},
 			{1, 9, 3, []int8{1, 4, 7}},
 			{-6, 6, 2, []int8{-6, -4, -2, 0, 2, 4, 6}},
 		}
 
 		for _, test := range tests {
-			assert.Equal(t, test.expected, Int8(test.start, test.end, Step(test.step)))
+			assert.Equal(t, test.expected, Range[int8](test.start, test.end, Step(test.step)))
 		}
 	})
 }
 
 func BenchmarkInt8(b *testing.B) {
 	for i := 1; i < b.N; i++ {
-		Int8(1, 127)
+		Range[int8](1, 127)
 	}
 }
 
 func TestInt16(t *testing.T) {
-	type testVals struct {
-		start    int16
-		end      int16
-		step     int
-		expected []int16
-	}
-
 	t.Run("It should generate intervals with a default step of 1", func(t *testing.T) {
-		tests := []testVals{
+		tests := []testVals[int16]{
 			{1, 10, 1, []int16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
 			{-5, 5, 1, []int16{-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5}},
 			{7, 7, 1, []int16{7}},
@@ -103,39 +90,32 @@ func TestInt16(t *testing.T) {
 		}
 
 		for _, test := range tests {
-			assert.Equal(t, test.expected, Int16(test.start, test.end))
+			assert.Equal(t, test.expected, Range[int16](test.start, test.end))
 		}
 	})
 
 	t.Run("It should generate intervals using the provided 'Step' option", func(t *testing.T) {
-		tests := []testVals{
+		tests := []testVals[int16]{
 			{1, 10, 3, []int16{1, 4, 7, 10}},
 			{1, 9, 3, []int16{1, 4, 7}},
 			{-6, 6, 2, []int16{-6, -4, -2, 0, 2, 4, 6}},
 		}
 
 		for _, test := range tests {
-			assert.Equal(t, test.expected, Int16(test.start, test.end, Step(test.step)))
+			assert.Equal(t, test.expected, Range[int16](test.start, test.end, Step(test.step)))
 		}
 	})
 }
 
 func BenchmarkInt16(b *testing.B) {
 	for i := 1; i < b.N; i++ {
-		Int16(1, 32767)
+		Range[int16](1, 32767)
 	}
 }
 
 func TestInt64(t *testing.T) {
-	type testVals struct {
-		start    int64
-		end      int64
-		step     int
-		expected []int64
-	}
-
 	t.Run("It should generate intervals with a default step of 1", func(t *testing.T) {
-		tests := []testVals{
+		tests := []testVals[int64]{
 			{1, 10, 1, []int64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
 			{-5, 5, 1, []int64{-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5}},
 			{7, 7, 1, []int64{7}},
@@ -143,39 +123,32 @@ func TestInt64(t *testing.T) {
 		}
 
 		for _, test := range tests {
-			assert.Equal(t, test.expected, Int64(test.start, test.end))
+			assert.Equal(t, test.expected, Range[int64](test.start, test.end))
 		}
 	})
 
 	t.Run("It should generate intervals using the provided 'Step' option", func(t *testing.T) {
-		tests := []testVals{
+		tests := []testVals[int64]{
 			{1, 10, 3, []int64{1, 4, 7, 10}},
 			{1, 9, 3, []int64{1, 4, 7}},
 			{-6, 6, 2, []int64{-6, -4, -2, 0, 2, 4, 6}},
 		}
 
 		for _, test := range tests {
-			assert.Equal(t, test.expected, Int64(test.start, test.end, Step(test.step)))
+			assert.Equal(t, test.expected, Range[int64](test.start, test.end, Step(test.step)))
 		}
 	})
 }
 
 func BenchmarkInt64(b *testing.B) {
 	for i := 1; i < b.N; i++ {
-		Int64(1, 1000000)
+		Range[int64](1, 1000000)
 	}
 }
 
 func TestUint(t *testing.T) {
-	type testVals struct {
-		start    uint
-		end      uint
-		step     int
-		expected []uint
-	}
-
 	t.Run("It should generate intervals with a default step of 1", func(t *testing.T) {
-		tests := []testVals{
+		tests := []testVals[uint]{
 			{1, 10, 1, []uint{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
 			{0, 5, 1, []uint{0, 1, 2, 3, 4, 5}},
 			{7, 7, 1, []uint{7}},
@@ -183,39 +156,32 @@ func TestUint(t *testing.T) {
 		}
 
 		for _, test := range tests {
-			assert.Equal(t, test.expected, Uint(test.start, test.end))
+			assert.Equal(t, test.expected, Range[uint](test.start, test.end))
 		}
 	})
 
 	t.Run("It should generate intervals using the provided 'Step' option", func(t *testing.T) {
-		tests := []testVals{
+		tests := []testVals[uint]{
 			{1, 10, 3, []uint{1, 4, 7, 10}},
 			{1, 9, 3, []uint{1, 4, 7}},
 			{0, 6, 2, []uint{0, 2, 4, 6}},
 		}
 
 		for _, test := range tests {
-			assert.Equal(t, test.expected, Uint(test.start, test.end, Step(test.step)))
+			assert.Equal(t, test.expected, Range[uint](test.start, test.end, Step(test.step)))
 		}
 	})
 }
 
 func BenchmarkUint(b *testing.B) {
 	for i := 1; i < b.N; i++ {
-		Uint(1, 1000000)
+		Range[uint](1, 1000000)
 	}
 }
 
 func TestUint8(t *testing.T) {
-	type testVals struct {
-		start    uint8
-		end      uint8
-		step     int
-		expected []uint8
-	}
-
 	t.Run("It should generate intervals with a default step of 1", func(t *testing.T) {
-		tests := []testVals{
+		tests := []testVals[uint8]{
 			{1, 10, 1, []uint8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
 			{0, 5, 1, []uint8{0, 1, 2, 3, 4, 5}},
 			{7, 7, 1, []uint8{7}},
@@ -223,39 +189,32 @@ func TestUint8(t *testing.T) {
 		}
 
 		for _, test := range tests {
-			assert.Equal(t, test.expected, Uint8(test.start, test.end))
+			assert.Equal(t, test.expected, Range[uint8](test.start, test.end))
 		}
 	})
 
 	t.Run("It should generate intervals using the provided 'Step' option", func(t *testing.T) {
-		tests := []testVals{
+		tests := []testVals[uint8]{
 			{1, 10, 3, []uint8{1, 4, 7, 10}},
 			{1, 9, 3, []uint8{1, 4, 7}},
 			{0, 6, 2, []uint8{0, 2, 4, 6}},
 		}
 
 		for _, test := range tests {
-			assert.Equal(t, test.expected, Uint8(test.start, test.end, Step(test.step)))
+			assert.Equal(t, test.expected, Range[uint8](test.start, test.end, Step(test.step)))
 		}
 	})
 }
 
 func BenchmarkUint8(b *testing.B) {
 	for i := 1; i < b.N; i++ {
-		Uint8(1, 255)
+		Range[uint8](1, 255)
 	}
 }
 
 func TestUint16(t *testing.T) {
-	type testVals struct {
-		start    uint16
-		end      uint16
-		step     int
-		expected []uint16
-	}
-
 	t.Run("It should generate intervals with a default step of 1", func(t *testing.T) {
-		tests := []testVals{
+		tests := []testVals[uint16]{
 			{1, 10, 1, []uint16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
 			{0, 5, 1, []uint16{0, 1, 2, 3, 4, 5}},
 			{7, 7, 1, []uint16{7}},
@@ -263,39 +222,32 @@ func TestUint16(t *testing.T) {
 		}
 
 		for _, test := range tests {
-			assert.Equal(t, test.expected, Uint16(test.start, test.end))
+			assert.Equal(t, test.expected, Range[uint16](test.start, test.end))
 		}
 	})
 
 	t.Run("It should generate intervals using the provided 'Step' option", func(t *testing.T) {
-		tests := []testVals{
+		tests := []testVals[uint16]{
 			{1, 10, 3, []uint16{1, 4, 7, 10}},
 			{1, 9, 3, []uint16{1, 4, 7}},
 			{0, 6, 2, []uint16{0, 2, 4, 6}},
 		}
 
 		for _, test := range tests {
-			assert.Equal(t, test.expected, Uint16(test.start, test.end, Step(test.step)))
+			assert.Equal(t, test.expected, Range[uint16](test.start, test.end, Step(test.step)))
 		}
 	})
 }
 
 func BenchmarkUint16(b *testing.B) {
 	for i := 1; i < b.N; i++ {
-		Uint16(1, 65535)
+		Range[uint16](1, 65535)
 	}
 }
 
 func TestUint64(t *testing.T) {
-	type testVals struct {
-		start    uint64
-		end      uint64
-		step     int
-		expected []uint64
-	}
-
 	t.Run("It should generate intervals with a default step of 1", func(t *testing.T) {
-		tests := []testVals{
+		tests := []testVals[uint64]{
 			{1, 10, 1, []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
 			{0, 5, 1, []uint64{0, 1, 2, 3, 4, 5}},
 			{7, 7, 1, []uint64{7}},
@@ -303,69 +255,52 @@ func TestUint64(t *testing.T) {
 		}
 
 		for _, test := range tests {
-			assert.Equal(t, test.expected, Uint64(test.start, test.end))
+			assert.Equal(t, test.expected, Range[uint64](test.start, test.end))
 		}
 	})
 
 	t.Run("It should generate intervals using the provided 'Step' option", func(t *testing.T) {
-		tests := []testVals{
+		tests := []testVals[uint64]{
 			{1, 10, 3, []uint64{1, 4, 7, 10}},
 			{1, 9, 3, []uint64{1, 4, 7}},
 			{0, 6, 2, []uint64{0, 2, 4, 6}},
 		}
 
 		for _, test := range tests {
-			assert.Equal(t, test.expected, Uint64(test.start, test.end, Step(test.step)))
+			assert.Equal(t, test.expected, Range[uint64](test.start, test.end, Step(test.step)))
 		}
 	})
 }
 
 func BenchmarkUint64(b *testing.B) {
 	for i := 1; i < b.N; i++ {
-		Uint64(1, 1000000)
+		Range[uint64](1, 1000000)
 	}
 }
 
 func TestFloat32(t *testing.T) {
-	type testVals struct {
-		start     float32
-		end       float32
-		step      int
-		floatStep float32
-		expected  []float32
-	}
-
 	t.Run("It should generate intervals with a default step of 1", func(t *testing.T) {
-		tests := []testVals{
-			{1, 10, 1, 1, []float32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
-			{-5, 5, 1, 1, []float32{-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5}},
-			{7, 7, 1, 1, []float32{7}},
-			{10, 1, 1, 1, []float32{}},
+		tests := []testVals[float32]{
+			{1, 10, 1, []float32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+			{-5, 5, 1, []float32{-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5}},
+			{7, 7, 1, []float32{7}},
+			{10, 1, 1, []float32{}},
 		}
 
 		for _, test := range tests {
-			assert.Equal(t, test.expected, Float32(test.start, test.end))
+			assert.Equal(t, test.expected, Range[float32](test.start, test.end))
 		}
 	})
 
 	t.Run("It should generate intervals using the provided 'Step' option", func(t *testing.T) {
-		tests := []testVals{
-			{1, 10, 3, 1, []float32{1, 4, 7, 10}},
+		tests := []testVals[float32]{
+			{1, 10, 3, []float32{1, 4, 7, 10}},
+			{1, 2, 0.3, []float32{1, 1.3, 1.6, 1.9}},
+			{1, 2.5, 0.5, []float32{1, 1.5, 2, 2.5}},
 		}
 
 		for _, test := range tests {
-			assert.Equal(t, test.expected, Float32(test.start, test.end, Step(test.step)))
-		}
-	})
-
-	t.Run("It should generate intervals using the provided 'FloatStep' option", func(t *testing.T) {
-		tests := []testVals{
-			{1, 2, 1, 0.3, []float32{1, 1.3, 1.6, 1.9}},
-			{1, 2.5, 3, 0.5, []float32{1, 1.5, 2, 2.5}},
-		}
-
-		for _, test := range tests {
-			actual := Float32(test.start, test.end, FloatStep(test.floatStep))
+			actual := Range[float32](test.start, test.end, Step(test.step))
 
 			for i := range actual {
 				assert.InDelta(t, test.expected[i], actual[i], 0.0001)
@@ -376,50 +311,33 @@ func TestFloat32(t *testing.T) {
 
 func BenchmarkFloat32(b *testing.B) {
 	for i := 1; i < b.N; i++ {
-		Float32(1, 1000000)
+		Range[float32](1, 1000000)
 	}
 }
 
 func TestFloat64(t *testing.T) {
-	type testVals struct {
-		start     float64
-		end       float64
-		step      int
-		floatStep float32
-		expected  []float64
-	}
-
 	t.Run("It should generate intervals with a default step of 1", func(t *testing.T) {
-		tests := []testVals{
-			{1, 10, 1, 1, []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
-			{-5, 5, 1, 1, []float64{-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5}},
-			{7, 7, 1, 1, []float64{7}},
-			{10, 1, 1, 1, []float64{}},
+		tests := []testVals[float64]{
+			{1, 10, 1, []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}},
+			{-5, 5, 1, []float64{-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5}},
+			{7, 7, 1, []float64{7}},
+			{10, 1, 1, []float64{}},
 		}
 
 		for _, test := range tests {
-			assert.Equal(t, test.expected, Float64(test.start, test.end))
+			assert.Equal(t, test.expected, Range[float64](test.start, test.end))
 		}
 	})
 
 	t.Run("It should generate intervals using the provided 'Step' option", func(t *testing.T) {
-		tests := []testVals{
-			{1, 10, 3, 1, []float64{1, 4, 7, 10}},
+		tests := []testVals[float64]{
+			{1, 10, 3, []float64{1, 4, 7, 10}},
+			{1, 2, 0.3, []float64{1, 1.3, 1.6, 1.9}},
+			{1, 2.5, 0.5, []float64{1, 1.5, 2, 2.5}},
 		}
 
 		for _, test := range tests {
-			assert.Equal(t, test.expected, Float64(test.start, test.end, Step(test.step)))
-		}
-	})
-
-	t.Run("It should generate intervals using the provided 'FloatStep' option", func(t *testing.T) {
-		tests := []testVals{
-			{1, 2, 1, 0.3, []float64{1, 1.3, 1.6, 1.9}},
-			{1, 2.5, 3, 0.5, []float64{1, 1.5, 2, 2.5}},
-		}
-
-		for _, test := range tests {
-			actual := Float64(test.start, test.end, FloatStep(test.floatStep))
+			actual := Range[float64](test.start, test.end, Step(test.step))
 
 			for i := range actual {
 				assert.InDelta(t, test.expected[i], actual[i], 0.0001)
@@ -430,7 +348,7 @@ func TestFloat64(t *testing.T) {
 
 func BenchmarkFloat64(b *testing.B) {
 	for i := 1; i < b.N; i++ {
-		Float64(1, 1000000)
+		Range[float64](1, 1000000)
 	}
 }
 


### PR DESCRIPTION
Greatly simplifies our range functions by upgrading to go v1.18 and
introducing generics for the generation of numeric ranges. All range
fucntions for generating ranges of integers and floats have been
replaced with a single 'Range[N Number]' function, whose type parameter
'N' accepts any integer or float type.